### PR TITLE
fix: recover search from transient failures

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -18,7 +18,6 @@ import json
 import multiprocessing
 import os
 import platform
-import random
 import re
 import sqlite3
 import struct
@@ -1162,8 +1161,7 @@ def _resolve_retry_config() -> tuple[int, int, int]:
 
 
 def _sleep_with_backoff(base_ms: int, max_ms: int, attempt: int) -> float:
-    cap_ms = min(max_ms, base_ms * (2 ** attempt))
-    delay_ms = random.uniform(base_ms, cap_ms)
+    delay_ms = min(max_ms, base_ms * (2 ** max(attempt - 1, 0)))
     time.sleep(delay_ms / 1000.0)
     return delay_ms
 

--- a/src/local_semble.py
+++ b/src/local_semble.py
@@ -58,21 +58,33 @@ def _build_index(
     content: list[str],
 ) -> tuple[Any, str]:
     SembleIndex, _, _, _, save_index_to_cache = _load_semble_api()
+    content_types = _content_types(content)
 
     try:
-        index = SembleIndex.from_path(project_root, content=_content_types(content))
+        index = SembleIndex.from_path(project_root, content=content_types)
     except Exception as exc:
-        raise SembleUnavailable(f"semble indexing failed: {exc}") from exc
+        cache_result = clear_project_cache(project_root)
+        if not cache_result["removed"]:
+            raise SembleUnavailable(f"semble indexing failed: {exc}") from exc
+        try:
+            index = SembleIndex.from_path(project_root, content=content_types)
+        except Exception as retry_exc:
+            raise SembleUnavailable(
+                f"semble indexing failed after cache recovery: {retry_exc}"
+            ) from retry_exc
+        cache_status = "recovered"
+    else:
+        cache_status = "hit" if getattr(index, "loaded_from_disk", False) else "miss"
 
     if getattr(index, "loaded_from_disk", False):
-        return index, "hit"
+        return index, cache_status
 
     try:
         save_index_to_cache(index, project_root)
     except Exception:
-        return index, "save_failed"
+        return index, "recovered_save_failed" if cache_status == "recovered" else "save_failed"
 
-    return index, "saved"
+    return index, "recovered" if cache_status == "recovered" else "saved"
 
 
 def _path_size(path: Path) -> int:

--- a/tests/test_local_semble.py
+++ b/tests/test_local_semble.py
@@ -237,6 +237,78 @@ class LocalSembleAdapterTest(unittest.TestCase):
         fake_save_index.assert_not_called()
         self.assertEqual(payload["_meta"]["cache"], "hit")
 
+    def test_search_recovers_from_corrupted_cached_index(self) -> None:
+        rebuilt_index = Mock()
+        rebuilt_index.loaded_from_disk = False
+        rebuilt_index.search.return_value = ["hit"]
+        fake_semble_index = Mock()
+        fake_semble_index.from_path.side_effect = [
+            json.JSONDecodeError("Extra data", "{}", 1),
+            rebuilt_index,
+        ]
+        fake_save_index = Mock()
+
+        with (
+            patch(
+                "local_semble._load_semble_api",
+                return_value=(
+                    fake_semble_index,
+                    _FakeContentType(),
+                    Mock(return_value={"query": "q", "results": ["hit"]}),
+                    Mock(),
+                    fake_save_index,
+                ),
+            ),
+            patch(
+                "local_semble.clear_project_cache",
+                return_value={"removed": True},
+            ) as mock_clear_cache,
+        ):
+            payload = local_semble.search(
+                query="q",
+                project_root=str(self.project_root),
+                top_k=2,
+                content=["code"],
+            )
+
+        resolved_root = str(self.project_root.resolve())
+        self.assertEqual(fake_semble_index.from_path.call_count, 2)
+        mock_clear_cache.assert_called_once_with(resolved_root)
+        fake_save_index.assert_called_once_with(rebuilt_index, resolved_root)
+        self.assertEqual(payload["_meta"]["cache"], "recovered")
+
+    def test_search_does_not_retry_without_existing_cache(self) -> None:
+        fake_semble_index = Mock()
+        fake_semble_index.from_path.side_effect = ValueError("source parsing failed")
+
+        with (
+            patch(
+                "local_semble._load_semble_api",
+                return_value=(
+                    fake_semble_index,
+                    _FakeContentType(),
+                    Mock(),
+                    Mock(),
+                    Mock(),
+                ),
+            ),
+            patch(
+                "local_semble.clear_project_cache",
+                return_value={"removed": False},
+            ),
+        ):
+            with self.assertRaisesRegex(
+                local_semble.SembleUnavailable,
+                "semble indexing failed: source parsing failed",
+            ):
+                local_semble.search(
+                    query="q",
+                    project_root=str(self.project_root),
+                    content=["code"],
+                )
+
+        fake_semble_index.from_path.assert_called_once()
+
 
 class LocalSembleCacheTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -20,6 +20,19 @@ class ModelFallbackTest(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
 
+    @patch("core.time.sleep")
+    def test_backoff_grows_exponentially_and_caps(self, mock_sleep) -> None:
+        delays = [
+            core._sleep_with_backoff(1000, 5000, attempt)
+            for attempt in range(1, 5)
+        ]
+
+        self.assertEqual(delays, [1000, 2000, 4000, 5000])
+        self.assertEqual(
+            [call.args[0] for call in mock_sleep.call_args_list],
+            [1.0, 2.0, 4.0, 5.0],
+        )
+
     @patch("core._search_once")
     @patch("core.check_rate_limit")
     @patch("core.time.sleep")


### PR DESCRIPTION
## Summary

- apply capped exponential backoff to transient remote search failures
- automatically clear and rebuild a corrupted Semble project cache once
- cover retry timing and cache recovery behavior with tests

## Verification

- `uv run python -m unittest discover -s tests`
- `uv run python -m compileall -q src tests`
- `git diff --check`
- real `fast-context local-search` smoke test