### PR TITLE
fix: serialize remote search across processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,15 @@ Auto-discovery checks Devin CLI credentials on Linux/WSL first, then local app d
 - `WINDSURF_API_KEY`: explicit credential override
 - `WS_MODEL`: optional model override. Default is `MODEL_SWE_1_6_FAST`
 - `WS_FALLBACK_MODELS`: optional comma-separated fallback chain. Default is `MODEL_SWE_1_5`
+- `WS_REMOTE_LOCK_PATH`: optional cross-process Windsurf lock file. Defaults to a per-user path under the system temp directory
+- `WS_REMOTE_LOCK_TIMEOUT_MS`: maximum wait for the shared remote slot. Default is `120000`
+- `WS_REMOTE_LOCK_POLL_MS`: lock retry interval. Default is `100`
 - `WS_APP_VER`
 - `WS_LS_VER`
 
 ## Model choice
+
+Remote Windsurf sessions are serialized per local user with an OS-level file lock. Local repo-map construction and Semble prefetch still run concurrently; only JWT acquisition, rate-limit checks, model retries, fallback, and the remote semantic loop share the slot. The OS releases the lock if a process exits unexpectedly. If lock waiting times out, `hybrid` degrades to its local Semble results instead of adding another remote request.
 
 Local testing on `2026-05-31` suggests these practical defaults:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -247,10 +247,15 @@ uv run fast-context extract-key --db-path ~/.local/share/devin/credentials.toml
 - `WINDSURF_API_KEY`：显式覆盖凭据
 - `WS_MODEL`：可选模型覆盖，默认 `MODEL_SWE_1_6_FAST`
 - `WS_FALLBACK_MODELS`：可选的逗号分隔 fallback 链，默认 `MODEL_SWE_1_5`
+- `WS_REMOTE_LOCK_PATH`：可选的跨进程 Windsurf 锁文件；默认使用系统临时目录下的用户级路径
+- `WS_REMOTE_LOCK_TIMEOUT_MS`：等待共享远端槽位的最长时间，默认 `120000`
+- `WS_REMOTE_LOCK_POLL_MS`：锁重试间隔，默认 `100`
 - `WS_APP_VER`
 - `WS_LS_VER`
 
 ## 模型选择
+
+同一用户的远端 Windsurf 会话会通过 OS 级文件锁串行执行。本地 repo map 和 Semble 预取仍可并行，只有 JWT 获取、限流检查、模型重试、fallback 和远端语义循环占用共享槽位。进程异常退出时 OS 会自动释放锁；等待超时后，`hybrid` 会降级到本地 Semble 结果，不再追加远端请求。
 
 基于 `2026-05-31` 在本地跑过的测试，当前比较顺手的默认值是：
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,7 @@ uv run --project "$SKILL_DIR" fast-context find-related \
 
 - Start with defaults.
 - Default `search` uses `--backend hybrid`: Semble prefetch first, Windsurf verification second, local results as degradation if remote fails.
+- Remote Windsurf sessions are serialized across local agents/processes with an OS-level file lock; local Semble and repo-map work remain concurrent.
 - Use `--backend remote` when you need to isolate Windsurf behavior without Semble hints.
 - Use `--backend local` or `local-search` for Semble-only chunk results.
 - Lower `--tree-depth` or add `--exclude` if payloads get large.

--- a/src/core.py
+++ b/src/core.py
@@ -14,6 +14,7 @@ Flow:
 from __future__ import annotations
 
 import gzip
+import hashlib
 import json
 import multiprocessing
 import os
@@ -24,12 +25,14 @@ import struct
 import subprocess
 import ssl
 import sys
+import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -574,6 +577,8 @@ DEFAULT_WS_FALLBACK_MODELS = ("MODEL_SWE_1_5",)
 DEFAULT_WS_RETRY_BASE_MS = 1000
 DEFAULT_WS_RETRY_MAX_MS = 5000
 DEFAULT_WS_MAX_RETRIES = 2
+DEFAULT_WS_REMOTE_LOCK_TIMEOUT_MS = 120000
+DEFAULT_WS_REMOTE_LOCK_POLL_MS = 100
 WS_APP_VER = os.environ.get("WS_APP_VER", "1.48.2")
 WS_LS_VER = os.environ.get("WS_LS_VER", "1.9544.35")
 
@@ -1116,6 +1121,99 @@ def _env_int(name: str, default: int, minimum: int = 0) -> int:
     return max(minimum, value)
 
 
+class RemoteSearchBusy(RuntimeError):
+    """Raised when another process holds the shared Windsurf search slot."""
+
+
+def _default_remote_lock_path() -> Path:
+    home_fingerprint = hashlib.sha256(str(Path.home()).encode("utf-8")).hexdigest()[:12]
+    lock_dir = Path(tempfile.gettempdir()) / f"fast-context-{home_fingerprint}"
+    lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return lock_dir / "windsurf-remote.lock"
+
+
+def _resolve_remote_lock_config() -> tuple[Path, int, int]:
+    configured_path = os.environ.get("WS_REMOTE_LOCK_PATH", "").strip()
+    lock_path = Path(configured_path).expanduser() if configured_path else _default_remote_lock_path()
+    timeout_ms = _env_int(
+        "WS_REMOTE_LOCK_TIMEOUT_MS",
+        DEFAULT_WS_REMOTE_LOCK_TIMEOUT_MS,
+        minimum=0,
+    )
+    poll_ms = _env_int(
+        "WS_REMOTE_LOCK_POLL_MS",
+        DEFAULT_WS_REMOTE_LOCK_POLL_MS,
+        minimum=10,
+    )
+    return lock_path, timeout_ms, poll_ms
+
+
+def _try_lock_file(file_obj: Any) -> bool:
+    file_obj.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            msvcrt.locking(file_obj.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    import fcntl
+
+    try:
+        fcntl.flock(file_obj.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock_file(file_obj: Any) -> None:
+    file_obj.seek(0)
+    if os.name == "nt":
+        import msvcrt
+
+        msvcrt.locking(file_obj.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(file_obj.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def _remote_search_slot(
+    on_progress: Callable[[str], None] | None = None,
+) -> Iterator[float]:
+    """Serialize Windsurf sessions across local agents and processes."""
+    lock_path, timeout_ms, poll_ms = _resolve_remote_lock_config()
+    lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    started = time.monotonic()
+
+    with lock_path.open("a+b") as lock_file:
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+
+        announced_wait = False
+        while not _try_lock_file(lock_file):
+            elapsed_ms = (time.monotonic() - started) * 1000
+            if elapsed_ms >= timeout_ms:
+                raise RemoteSearchBusy(
+                    f"远端搜索槽位等待超时（{timeout_ms}ms）：{lock_path}"
+                )
+            if on_progress and not announced_wait:
+                on_progress("另一个 Fast Context 进程正在使用远端搜索，等待共享槽位...")
+                announced_wait = True
+            time.sleep(poll_ms / 1000.0)
+
+        waited_ms = (time.monotonic() - started) * 1000
+        try:
+            yield waited_ms
+        finally:
+            _unlock_file(lock_file)
+
+
 def _resolve_model_candidates(primary_model: str | None = None) -> list[str]:
     primary = (primary_model or os.environ.get("WS_MODEL", DEFAULT_WS_MODEL)).strip()
     fallback_raw = os.environ.get("WS_FALLBACK_MODELS")
@@ -1617,81 +1715,26 @@ def _search_once(
     }
 
 
-def search(
+def _search_remote_models(
+    *,
     query: str,
     project_root: str,
-    api_key: str | None = None,
-    jwt: str | None = None,
-    max_turns: int = 3,
-    max_commands: int = 8,
-    max_results: int = 10,
-    tree_depth: int = 3,
-    timeout_ms: int = 30000,
-    exclude_paths: list[str] | None = None,
-    local_context: str | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    api_key: str,
+    jwt: str,
+    system_prompt: str,
+    tool_defs: list[dict[str, Any]],
+    user_content: str,
+    max_turns: int,
+    timeout_ms: int,
+    actual_depth: int,
+    tree_size_bytes: int,
+    fell_back: bool,
+    repo_map_meta: dict[str, Any],
+    on_progress: Callable[[str], None] | None,
 ) -> Dict[str, Any]:
-    """
-    执行 Fast Context 搜索。
-
-    Args:
-        query: 自然语言搜索查询
-        project_root: 项目根目录
-        api_key: Windsurf API key（不传则自动获取）
-        jwt: JWT token（不传则自动获取）
-        max_turns: 搜索轮数（默认 3，与 Windsurf 原版一致）
-        max_commands: 每轮最大命令数（默认 8）
-        max_results: 最多返回的文件数量
-        tree_depth: repo map 目标深度（1-6）
-        timeout_ms: 流式请求超时
-        exclude_paths: 额外排除路径
-        local_context: 本地检索候选 chunk，注入远端搜索提示
-        on_progress: 进度回调
-
-    Returns:
-        {"files": [...], "error": "..."} 或 {"files": [...]}
-    """
     def log(msg: str) -> None:
         if on_progress:
             on_progress(msg)
-
-    project_root = os.path.abspath(project_root)
-    exclude_paths = exclude_paths or []
-
-    if not api_key:
-        api_key = get_api_key()
-    if not jwt:
-        log("获取 JWT...")
-        jwt = fetch_jwt(api_key)
-
-    tool_defs = get_tool_definitions(max_commands)
-    system_prompt = build_system_prompt(max_turns, max_commands, max_results)
-
-    repo_map, actual_depth, tree_size_bytes, fell_back, repo_map_meta = _get_repo_map_with_meta(
-        project_root,
-        query,
-        tree_depth,
-        exclude_paths,
-    )
-    hot_dirs = repo_map_meta.get("hot_dirs") or []
-    log(
-        f"Repo map: tree -L {actual_depth} "
-        f"({tree_size_bytes / 1024:.1f}KB)"
-        f"{' [fell back]' if fell_back else ''}"
-        f" [strategy={repo_map_meta.get('repo_map_strategy')}]"
-        f"{f' [hot={','.join(hot_dirs)}]' if hot_dirs else ''}"
-    )
-    local_anchor_brief = build_local_anchor_brief(
-        query,
-        project_root,
-        _effective_excludes(exclude_paths),
-    )
-    user_content = "\n\n".join([
-        f"Problem Statement: {query}",
-        local_context or "",
-        local_anchor_brief,
-        f"Repo Map (tree -L {actual_depth} /codebase):\n```text\n{repo_map}\n```",
-    ]).strip()
 
     model_candidates = _resolve_model_candidates()
     retry_base_ms, retry_max_ms, max_model_retries = _resolve_retry_config()
@@ -1700,7 +1743,10 @@ def search(
     for index, model in enumerate(model_candidates, 1):
         for retry_count in range(max_model_retries + 1):
             if retry_count:
-                log(f"检查模型 {model} ({index}/{len(model_candidates)})，重试 {retry_count}/{max_model_retries}")
+                log(
+                    f"检查模型 {model} ({index}/{len(model_candidates)})，"
+                    f"重试 {retry_count}/{max_model_retries}"
+                )
             else:
                 log(f"检查模型 {model} ({index}/{len(model_candidates)})")
 
@@ -1778,6 +1824,117 @@ def search(
             **repo_map_meta,
         },
     }
+
+
+def search(
+    query: str,
+    project_root: str,
+    api_key: str | None = None,
+    jwt: str | None = None,
+    max_turns: int = 3,
+    max_commands: int = 8,
+    max_results: int = 10,
+    tree_depth: int = 3,
+    timeout_ms: int = 30000,
+    exclude_paths: list[str] | None = None,
+    local_context: str | None = None,
+    on_progress: Callable[[str], None] | None = None,
+) -> Dict[str, Any]:
+    """
+    执行 Fast Context 搜索。
+
+    Args:
+        query: 自然语言搜索查询
+        project_root: 项目根目录
+        api_key: Windsurf API key（不传则自动获取）
+        jwt: JWT token（不传则自动获取）
+        max_turns: 搜索轮数（默认 3，与 Windsurf 原版一致）
+        max_commands: 每轮最大命令数（默认 8）
+        max_results: 最多返回的文件数量
+        tree_depth: repo map 目标深度（1-6）
+        timeout_ms: 流式请求超时
+        exclude_paths: 额外排除路径
+        local_context: 本地检索候选 chunk，注入远端搜索提示
+        on_progress: 进度回调
+
+    Returns:
+        {"files": [...], "error": "..."} 或 {"files": [...]}
+    """
+    def log(msg: str) -> None:
+        if on_progress:
+            on_progress(msg)
+
+    project_root = os.path.abspath(project_root)
+    exclude_paths = exclude_paths or []
+
+    if not api_key:
+        api_key = get_api_key()
+
+    tool_defs = get_tool_definitions(max_commands)
+    system_prompt = build_system_prompt(max_turns, max_commands, max_results)
+
+    repo_map, actual_depth, tree_size_bytes, fell_back, repo_map_meta = _get_repo_map_with_meta(
+        project_root,
+        query,
+        tree_depth,
+        exclude_paths,
+    )
+    hot_dirs = repo_map_meta.get("hot_dirs") or []
+    log(
+        f"Repo map: tree -L {actual_depth} "
+        f"({tree_size_bytes / 1024:.1f}KB)"
+        f"{' [fell back]' if fell_back else ''}"
+        f" [strategy={repo_map_meta.get('repo_map_strategy')}]"
+        f"{f' [hot={','.join(hot_dirs)}]' if hot_dirs else ''}"
+    )
+    local_anchor_brief = build_local_anchor_brief(
+        query,
+        project_root,
+        _effective_excludes(exclude_paths),
+    )
+    user_content = "\n\n".join([
+        f"Problem Statement: {query}",
+        local_context or "",
+        local_anchor_brief,
+        f"Repo Map (tree -L {actual_depth} /codebase):\n```text\n{repo_map}\n```",
+    ]).strip()
+
+    try:
+        with _remote_search_slot(on_progress=on_progress) as lock_wait_ms:
+            if not jwt:
+                log("获取 JWT...")
+                jwt = fetch_jwt(api_key)
+            result = _search_remote_models(
+                query=query,
+                project_root=project_root,
+                api_key=api_key,
+                jwt=jwt,
+                system_prompt=system_prompt,
+                tool_defs=tool_defs,
+                user_content=user_content,
+                max_turns=max_turns,
+                timeout_ms=timeout_ms,
+                actual_depth=actual_depth,
+                tree_size_bytes=tree_size_bytes,
+                fell_back=fell_back,
+                repo_map_meta=repo_map_meta,
+                on_progress=on_progress,
+            )
+            result.setdefault("_meta", {})["remote_lock_wait_ms"] = round(lock_wait_ms, 1)
+            return result
+    except RemoteSearchBusy as exc:
+        return {
+            "files": [],
+            "error": str(exc),
+            "_meta": {
+                "tree_depth": actual_depth,
+                "tree_size_kb": round(tree_size_bytes / 1024, 1),
+                "fell_back": fell_back,
+                "project_root": project_root,
+                "error_code": "remote_lock_timeout",
+                **repo_map_meta,
+            },
+        }
 
 
 def _parse_answer(xml_text: str, project_root: str) -> Dict[str, Any]:

--- a/tests/test_remote_lock.py
+++ b/tests/test_remote_lock.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import os
+import multiprocessing
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import core  # noqa: E402
+
+
+def _acquire_remote_slot_in_child(result_queue: multiprocessing.Queue) -> None:
+    with core._remote_search_slot():
+        result_queue.put("acquired")
+
+
+class RemoteSearchLockTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.lock_path = str(Path(self.temp_dir.name) / "remote.lock")
+        self.env = patch.dict(
+            os.environ,
+            {
+                "WS_REMOTE_LOCK_PATH": self.lock_path,
+                "WS_REMOTE_LOCK_TIMEOUT_MS": "1000",
+                "WS_REMOTE_LOCK_POLL_MS": "10",
+            },
+            clear=False,
+        )
+        self.env.start()
+
+    def tearDown(self) -> None:
+        self.env.stop()
+        self.temp_dir.cleanup()
+
+    def test_remote_slot_serializes_concurrent_callers(self) -> None:
+        second_acquired = threading.Event()
+        second_finished = threading.Event()
+
+        def enter_second_slot() -> None:
+            with core._remote_search_slot():
+                second_acquired.set()
+            second_finished.set()
+
+        with core._remote_search_slot():
+            worker = threading.Thread(target=enter_second_slot)
+            worker.start()
+            time.sleep(0.05)
+            self.assertFalse(second_acquired.is_set())
+
+        worker.join(timeout=1)
+        self.assertTrue(second_acquired.is_set())
+        self.assertTrue(second_finished.is_set())
+
+    def test_remote_slot_serializes_separate_processes(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        result_queue = context.Queue()
+
+        with core._remote_search_slot():
+            worker = context.Process(
+                target=_acquire_remote_slot_in_child,
+                args=(result_queue,),
+            )
+            worker.start()
+            time.sleep(0.1)
+            self.assertTrue(result_queue.empty())
+
+        worker.join(timeout=2)
+        self.assertEqual(worker.exitcode, 0)
+        self.assertEqual(result_queue.get(timeout=1), "acquired")
+
+    def test_remote_slot_times_out_without_leaking_lock(self) -> None:
+        with core._remote_search_slot():
+            with patch.dict(
+                os.environ,
+                {"WS_REMOTE_LOCK_TIMEOUT_MS": "20"},
+                clear=False,
+            ):
+                with self.assertRaises(core.RemoteSearchBusy):
+                    with core._remote_search_slot():
+                        self.fail("contended slot should not be acquired")
+
+        with core._remote_search_slot() as waited_ms:
+            self.assertGreaterEqual(waited_ms, 0)
+
+    def test_remote_slot_releases_after_exception(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with core._remote_search_slot():
+                raise RuntimeError("boom")
+
+        with core._remote_search_slot():
+            pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- serialize Windsurf remote sessions across local agents and processes with an OS-level file lock
- keep local Semble prefetch and repo-map construction concurrent
- bound lock waiting and let hybrid searches degrade to local results on timeout
- document lock configuration for macOS, Linux, and Windows

## Validation

- `uv run python -m unittest discover -s tests -v` (28/28)
- includes thread and spawned-process contention tests
- `uv run python -m compileall -q src tests`
- `git diff --check`